### PR TITLE
fix: don't abort whole pricelist import on a single domain error

### DIFF
--- a/src/SpojeNet/SubregAbraFlexi/SubregPricelist.php
+++ b/src/SpojeNet/SubregAbraFlexi/SubregPricelist.php
@@ -49,23 +49,29 @@ class SubregPricelist extends \AbraFlexi\Cenik
         foreach ($domainsToProcess as $domain => $domainInfo) {
             $synced = false;
 
-            if (\array_key_exists('prices', $domainInfo)) {
-                $domainInfo['name'] = $domain;
-                $prices = $domainInfo['prices'];
+            if (!\array_key_exists('prices', $domainInfo)) {
+                $this->addStatusMessage($domain.': '._('No prices provided ?!?'), 'warning');
+                $report['fail'][$domain] = $domainInfo;
 
+                continue;
+            }
+
+            $domainInfo['name'] = $domain;
+            $prices = $domainInfo['prices'];
+
+            // A single domain must never abort the whole pricelist import:
+            // AbraFlexi may answer with a transient 5xx for one record.
+            try {
                 if ((\array_key_exists('register', $prices) && \array_key_exists('renew', $prices)) && ($prices['register'] === $prices['renew'])) {
                     $synced = $this->saveDomain('common', $domainInfo);
                 } else {
+                    $synced = true;
+
                     foreach ($prices as $priceType => $priceValue) {
                         switch ($priceType) {
                             case 'renew':
                             case 'register':
-                                try {
-                                    $synced = $this->saveDomain($priceType, $domainInfo);
-                                } catch (\AbraFlexi\Exception $exc) {
-                                    echo $exc->getTraceAsString();
-                                    $this->addStatusMessage('Error importing domain: '.$domain, 'error');
-                                }
+                                $synced = $this->saveDomain($priceType, $domainInfo) && $synced;
 
                                 break;
                             case 'ea1':
@@ -94,11 +100,12 @@ class SubregPricelist extends \AbraFlexi\Cenik
                         }
                     }
                 }
-
-                $this->addStatusMessage($domain.': '.(++$position).'/'.\count($domainsToProcess).' '.$this->getRecordCode(), $synced ? 'success' : 'error');
-            } else {
-                $this->addStatusMessage($domain.': '._('No prices provided ?!?'), 'warning');
+            } catch (\AbraFlexi\Exception $exc) {
+                $synced = false;
+                $this->addStatusMessage('Error importing domain '.$domain.': '.$exc->getMessage(), 'error');
             }
+
+            $this->addStatusMessage($domain.': '.(++$position).'/'.\count($domainsToProcess).' '.$this->getRecordCode(), $synced ? 'success' : 'error');
 
             $report[$synced ? 'success' : 'fail'][$domain] = $domainInfo;
         }

--- a/src/subreg2abraflexi.php
+++ b/src/subreg2abraflexi.php
@@ -47,6 +47,11 @@ try {
 
     $written = file_put_contents($destination, json_encode($report, \Ease\Shared::cfg('DEBUG') ? \JSON_PRETTY_PRINT : 0));
     $syncer->addStatusMessage(sprintf(_('Saving result to %s'), $destination), $written ? 'success' : 'error');
+
+    if (!empty($report['fail'])) {
+        fwrite(\STDERR, sprintf('%d of %d domains failed to import'.\PHP_EOL, \count($report['fail']), $report['domains']));
+        $exitcode = 2;
+    }
 } catch (\SoapFault $exc) {
     fwrite(\STDERR, 'SOAP connection error: '.$exc->getMessage().\PHP_EOL);
     $exitcode = 1;


### PR DESCRIPTION
## Problem

Zabbix raised a Disaster alert on `multi.spojenet.cz`:

> **`job-[SPOJENET-AFLEXI1-Import ceníku domén]` exited with error** (exitcode `2`, MultiFlexi job_id `260128`)

The MultiFlexi job log showed the import died at **58 / 1221** domains (right after `autos`):

```
💀 AbraFlexi\RW: Unexpected response data [500]: {"success":"false", ...
   "errors":[{"message":"Internal application error.","messageCode":"importXmlInternalError"}]}
   for https://flexibee.freetel.cz:5434/c/spoje_net_s_r_o_/dodavatel
```

AbraFlexi returned a transient **HTTP 500** while writing the supplier (`dodavatel`) record for one domain.

## Root cause

In `SubregPricelist::import()`, the `'common'` price branch called `saveDomain()` → `saveDomainPrice()` (writes to `dodavatel`) **with no exception handling** — only the `register`/`renew` branch was wrapped. The resulting `\AbraFlexi\Exception` propagated up to `main`, was caught by the generic handler → `exit(2)`, aborting the **entire** 1221-domain import.

## Fix

- **`SubregPricelist.php`** — wrap each domain's full processing (both `common` and `register`/`renew` paths) in a single `try/catch (\AbraFlexi\Exception)`. One failed domain is logged and skipped; the rest of the pricelist still imports.
- **`subreg2abraflexi.php`** — after the run, if any domains landed in `$report['fail']`, write a `"N of M domains failed"` line to STDERR and exit `2`, so Zabbix still alerts on residual failures (no longer a misleading "stopped at 58/1221").

Both files pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of domain price data during synchronization to prevent processing of incomplete records
  * Enhanced error reporting with clearer status messages for failed domain imports
  * Fixed process exit code handling to properly indicate when import operations have failed
  * Strengthened exception handling for more reliable import operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->